### PR TITLE
Permite Object genérico como type em CreateTheme

### DIFF
--- a/prensa_tokens.d.ts
+++ b/prensa_tokens.d.ts
@@ -36,6 +36,12 @@ export type Colors = {
   [key in ColorTokens]: string;
 }
 
+export type Factors = {
+  dimensions: number;
+  padding: number;
+  margin: number;
+}
+
 export type Fonts = {
   [key in FontTokens]: string;
 }
@@ -54,10 +60,4 @@ export type Teasers = {
 
 export type Templates = {
   [key in TemplateCartridges];
-}
-
-export type Factors = {
-  dimensions: number;
-  padding: number;
-  margin: number;
 }

--- a/src/styles/theme/CreateFunction.ts
+++ b/src/styles/theme/CreateFunction.ts
@@ -17,7 +17,7 @@ export interface ThemeTypes {
  * CreateTheme function docs
  * @param {object} data - An object that defines/overrides properties in theme
  */
-export function CreateTheme(data: ThemeTypes) {
+export function CreateTheme(data: ThemeTypes | Object) {
   return merge(default_theme, data)
 }
 


### PR DESCRIPTION
Evita que o typescript emita um erro ao adicionar propriedades customizadas (não tipadas) no theme