### PR TITLE
Nova lógica para renderizar espaço vazio quando o subject for inexistente

### DIFF
--- a/src/components/Article/Subject/Subject.js
+++ b/src/components/Article/Subject/Subject.js
@@ -19,34 +19,38 @@ const Subject = ({
   transform,
   value
 }) => {
-  return (
-    <Block 
-      bgColor={bgColor}
-      custom={`
-        border-radius: ${borderRadius};
-      `}
-      mb={mb[0]}
-      mt={mt[0]}
-      px={px}
-      py={py}
-      lg={{
-        mb: mb[1],
-        mt: mt[1]
-      }}>
-      <Typography 
+
+  const hasValue = value !== ''
+
+  const RenderText = () => {
+    if (!hasValue) return null
+    return (
+      <Typography
         color={color}
-        dangerouslySetInnerHTML={value}
         element='span'
         fontFamily={fontFamily}
         fontSize={fontSize[0]}
         fontWeight={fontWeight}
         lineHeight={lineHeight[0]}
-        lg={{
-          fontSize: fontSize[1],
-          lineHeight: lineHeight[1]
-        }}
+        lg={{ fontSize: fontSize[1], lineHeight: lineHeight[1] }}
         transform={transform}
-      />
+      >
+        {value}
+      </Typography>
+    )
+  }
+
+  return (
+    <Block
+      bgColor={hasValue ? bgColor : undefined}
+      custom={`border-radius: ${borderRadius};`}
+      mb={mb[0]}
+      mt={mt[0]}
+      px={px}
+      py={py}
+      lg={{ mb: mb[1], mt: mt[1] }}
+    >
+      <RenderText />
     </Block>
   )
 }
@@ -63,8 +67,7 @@ Subject.defaultProps = {
   mb: [1, 2],
   mt: [2, 4],
   px: 2,
-  py: '4px',
-  value: 'MÍDIA DIGITAL'
+  py: '4px'
 }
 
 Subject.propTypes = {


### PR DESCRIPTION
### O que esse PR implementa?
Nova lógica no componente subject que remove sinais visuais do subject quando não há texto para ser renderizado. Uma div é renderizada no lugar do texto quando `value` é vazio.

![image](https://user-images.githubusercontent.com/24513129/139160972-a58030eb-150e-47e5-9065-c5faa41f8711.png)

![Oct-27-2021 20-23-12](https://user-images.githubusercontent.com/24513129/139161449-d4d56c2c-8062-4dee-a781-de7dd9272af3.gif)
)
